### PR TITLE
fix: Change user_agent to avoid out-of-date version

### DIFF
--- a/venemy.py
+++ b/venemy.py
@@ -86,7 +86,7 @@ def authenticate():
 def GetDataFromVenmo(url):
 	try:
 		api_key = config['venmo.com']['api_token']
-		user_agent = "Venmo/7.38.0 (iPhone; iOS 13.0; Scale/2.0)"
+		user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.121 Safari/537.36"
 		headers = {'User-Agent':user_agent, 'Authorization': 'Bearer '+ api_key}
 		response = requests.get(url, headers=headers,verify=False)
 		return response


### PR DESCRIPTION
Currently, if I use `user_agent = "Venmo/7.38.0 (iPhone; iOS 13.0; Scale/2.0)"`, I get the following error:

```
{'error': {'message': 'In order to continue accessing your account, please update to the latest version of the app or log onto our website at https://venmo.com/', 'title': 'Update your Venmo app to continue signing in', 'code': 2, 'links': []}}
```

I believe this is because the API version `7.38.0` is out of date. I don't think it needs to be included in the user agent. Thought I'd suggest a fix!